### PR TITLE
Add per-date cache key, extract the main loop into another function

### DIFF
--- a/app/api/v1/services/kbri_service.py
+++ b/app/api/v1/services/kbri_service.py
@@ -16,59 +16,69 @@ class KbriService:
 
     async def get_schedule(self, slot_limit: int) -> Optional[Dict[str, Any]]:
         redis = self.redis_service.initialize_redis()
+        at = datetime.date.today()
         slots = []
-        date_counter = 0
         limit = self.default_slot_limit
         if slot_limit <= 10:
             limit = slot_limit
 
-        cache_object = await redis.get(self.kbri_cache_key)
-        if cache_object:
-            slots = json.loads(cache_object.decode('utf-8'))
-
-            if limit <= len(slots):
-                return slots[:limit]
-
-        while True:
-            date_ = datetime.strftime(
-                (datetime.now() + timedelta(days=date_counter)),
-                '%d-%m-%Y'
-            )
-            response = self.third_party_service.call(
-                'GET',
-                f'{settings.KBRI_HOST}/index.php/ajax/get_day/{date_}',
-                None,
-            )
-            date_counter += 1
-
-            if [slot for slot in slots if slot['date'] == date_]:
-                print(f'Skipping date={date_} exists in slots')
-
+        while len(slots) < limit:
+            at += timedelta(days=1)
+            slot = self.get_slot(redis, at, False)
+            if not slot:
                 continue
 
-            if response.text.replace('"', '') in ['libur', 'penuh', 'lewat']:
-                print(
-                    f'Skipping {date_} due to {response.text}',
-                )
+            slots.append(slot)
 
-                continue
+        return slots
 
-            response = response.json()
+    async def get_cache_key(
+        self, 
+        at: datetime,
+    ) -> str:
+        formatted_date = datetime.strftime(at, '%Y-%m-%d')
 
-            slots.append(
-                {
-                    'date' : date_,
-                    'time': ', '.join(response[1]),
-                },
+        return f'{self.kbri_cache_key}:{formatted_date}'
+
+    async def get_slot(
+        self,
+        redis: RedisService,
+        at: datetime,
+        skip_cache: bool,
+    ) -> Dict[str, Any]:
+        cache_key = self.get_cache_key(at)
+        if not skip_cache:
+            cache_object = await redis.get(cache_key)
+            if cache_object:
+                return json.loads(cache_object.decode('utf-8'))
+
+        date_ = datetime.strftime(
+            at,
+            '%d-%m-%Y'
+        )
+        response = self.third_party_service.call(
+            'GET',
+            f'{settings.KBRI_HOST}/index.php/ajax/get_day/{date_}',
+            None,
+        )
+
+        if response.text.replace('"', '') in ['libur', 'penuh', 'lewat']:
+            print(
+                f'Skipping {date_} due to {response.text}',
             )
 
-            if limit <= len(slots):
-                await redis.setex(
-                    self.kbri_cache_key,
-                    self.expire_cache,
-                    json.dumps(slots),
-                )
+            return None
 
-                break
+        response = response.json()
+        slot = {
+            'date' : date_,
+            'time': ', '.join(response[1]),
+        }
 
-        return slots[:limit]
+        await redis.setex(
+            cache_key,
+            self.expire_cache,
+            json.dumps(slot),
+        )
+
+        return slot


### PR DESCRIPTION
Hello @opatua,

I made a few changes to your `kbri_service.py` for your approval:
1. The cache is now per date.
Having a different cache key for each day allows for a more fine-grained control over expiry.
**Warning: this unfortunately renders your existing cache invalid**

2. The main content of the loop is extracted out to another function so that it's easier to maintain

3. Instead of recalculating date based on the current time, the current date is stored in a variable, which gets incremented in every loop.
The previous implementation (recalculating now plus `date_counter` number of days has one potential edge case, which is if the loop happen across different days, the code will skip one day
**Example:**
The first iteration began at 2022-03-11T23:59:59, `date_counter` is 0, so we load slots of 2022-03-11
The second iteration began at 2022-03-12T00:00:00, `date_counter` is 1, so we load slots of 2022-03-13
Note that 2022-03-12 is skipped

## Future enhancements
1. When a date is sold out, we can safely cache that information for a longer time (or even forever), because a sold out date is unlikely to revert into an available date

2. Would recommend using time-zone-aware timestamp, set to the time zone of the branch (e.g., `Asia/Kuala_Lumpur`). The current implementation will follow the server's time zone (usually `UTC`), which meant it's still "yesterday" up till 08:00 Asia/Kuala_Lumpur time